### PR TITLE
replace some search-and-replace setup with lookup on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,22 @@ To install:
 
 To create a member:
 
-Type `node` and enter the following commands, replacing the username and key dir with your own.
+Type `node` and enter the following commands, replacing the email
+address and key dir with your own.
 
 * `var TokenLib = require("token-io/dist/token-io.node.js");`
 * `var Token = new TokenLib('sandbox', './keys');`
-* `var alias = {type: 'USERNAME', value: 'mariano876'};`
+* `var alias = {type: 'EMAIL', value: 'mariano876@example.com'};`
 * `Token.createMember(alias, Token.UnsecuredFileCryptoEngine)`
 
 To run the server:
 
-1. Change the username to the one used above, index.html
+1. In server.js, change the email address to the one you used above.
+   If you didn't use ./keys as the key dir above, it that in server.js also.
 
-2. Change the memberId in server.js to the filename in the your keys directory, replacing the underscores _ with colons :
+2. run `node server.js`
 
-3. run `node server.js`
-
-4. Test by going to localhost:3000.
+3. Test by going to localhost:3000.
    You can't get far until you create a customer member as described at the
    [Merchant Quick Checkout documentation](http://developer.token.io/merchant-checkout/).
 

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
       }).bindPayButton(
          {
              alias: {
-                 type: 'USERNAME',
-                 value: 'mariano221'     // Merchant Alias
+                 type: 'EMAIL',
+                 value: '{alias}'        // address filled in by server.js
              },
              amount: 4.99,               // Amount
              currency: 'EUR',            // Currency

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "body-parser": "^1.17.2",
     "express": "^4.15.4",
-    "token-io": "^1.4.94"
+    "token-io": "^1.4.96"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,9 @@
 'use strict';
+
+const address = 'mariano876@example.com';
+
 var express = require('express')
+const fs = require('fs')
 var app = express()
 var bodyParser = require('body-parser');
 var urlencodedParser = bodyParser.urlencoded({ extended: false })
@@ -8,11 +12,18 @@ var urlencodedParser = bodyParser.urlencoded({ extended: false })
 var TokenLib = require("token-io/dist/token-io.node.js");
 var Token = new TokenLib('sandbox', './keys');
 
-// Initializes the server..
-var member = Token.login(
-    Token.UnsecuredFileCryptoEngine,
-    'm:3UPKC9ybzuKauwxVSsBiLbcEaj6k:5zKtXEAq');
-console.log('Logged in as: ', member.memberId());
+// Initializes the server.
+
+var member; // merchant member
+Token.resolveAlias({ // look up merchant member's ID by address...
+    type: 'EMAIL',
+    value: address
+}).then( function(structWithMemberId) { // ...and log in using keys
+    member = Token.login(
+        Token.UnsecuredFileCryptoEngine,
+        structWithMemberId.id);
+    console.log('Logged in as: ', member.memberId());
+});
 
 var destinations = [{
     account: {
@@ -34,9 +45,12 @@ app.post('/transfer', urlencodedParser, function (req, res) {
     });
 })
 
-// Returns HTML file
+// Returns HTML file with {alias} replaced by email address
 app.get('/', function (req, res) {
-  res.sendFile('index.html', {root: __dirname });
+    fs.readFile('index.html', 'utf8', function (err, contents) {
+        res.set('Content-Type', 'text/html');
+        res.send(contents.replace(/{alias}/g, address));
+    })
 })
 
 // Starts the server


### PR DESCRIPTION
remove some of the search-and-replace set-up work with server logic. Good news: less setup work. Bad news: server gets more complex; I'm honestly not sure it's worth it.

When I say "not sure it's worth it", I'm looking at the code that looks up the member Id. Mmmaybe instead of making sdk "customers" have this logi, sdk-js could have an API like Token.login but that takes an alias and does the lookup. Then this here server could use that API.

(a) Let's not change sdk-js. Go ahead and ship merchant-sample-js like this.

(b) Yeah, let's change sdk-js. Larry, please put together a PR

(c) Let's not do either of those.