### PR TITLE
add +noverify to starter email address just in case

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var TokenLib = require("token-io/dist/token-io.node.js");
 
 var Token = new TokenLib('sandbox','4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI', './keys');
 
-var alias = {type: 'EMAIL', value: 'mariano876@example.com'};
+var alias = {type: 'EMAIL', value: 'mariano876+noverify@example.com'};
 
 Token.createMember(alias, Token.UnsecuredFileCryptoEngine);
 ```
@@ -29,7 +29,7 @@ Token.createMember(alias, Token.UnsecuredFileCryptoEngine);
 To run the server:
 
 1. In server.js, change the email address to the one you used above.
-   If you didn't use ./keys as the key dir above, it that in server.js also.
+   If you didn't use ./keys as the key dir above, change it in server.js also.
 
 2. run `node server.js`
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const address = 'mariano876@example.com';
+const address = 'mariano876+noverify@example.com';
 
 var express = require('express')
 const fs = require('fs')


### PR DESCRIPTION
nobody's grabbed it since the last test db purge
and then are surprised it doesn't work because they
didn't verify it. (And if there is anyone watching
that example.com email address, they would be happier
without verification emails from us, no doubt)

Also, fix a missing verb in README file.