### PR TITLE
instead of using a handmade merchant member, randomly autocreate one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Token Merchant Checkout Sample
+## Token Merchant Checkout Sample: Javascript
 
 This sample app shows how to integrate the Token Merchant Quick Checkout
 button into a merchant's website.
@@ -7,38 +7,29 @@ You can learn more about the Quick Checkout flow and relevant APIs at the
 
 ### Setup
 
-To install:
+To install, `npm install`
 
-`npm install`
+To run, `node server.js`
 
-To create a member:
+This starts up a server.
 
-Type `node` and enter the following commands, replacing the email
-address and key dir with your own.
+The first time you run the server, it creates a new Member (Token user account).
+It saves the Member's private keys in the `keys` directory.
+In subsequent runs, the server uses this ID these keys to log the Member in.
 
-```
-var TokenLib = require("token-io/dist/token-io.node.js");
+The server operates in Token's Sandbox environment. This testing environment
+lets you try out UI and payment flows without moving real money.
 
-var Token = new TokenLib('sandbox','4qY7lqQw8NOl9gng0ZHgT4xdiDqxqoGVutuZwrUYQsI', './keys');
+The server shows a web page at `localhost:3000`. The page has a checkout button.
+Clicking the button starts the Token merchant payment flow.
+The server handles endorsed payments by redeeming tokens.
 
-var alias = {type: 'EMAIL', value: 'mariano876+noverify@example.com'};
+Test by going to `localhost:3000`.
+You can't get far until you create a customer member as described at the
+[Merchant Quick Checkout documentation](https://developer.token.io/merchant-checkout/).
 
-Token.createMember(alias, Token.UnsecuredFileCryptoEngine);
-```
-
-To run the server:
-
-1. In server.js, change the email address to the one you used above.
-   If you didn't use ./keys as the key dir above, change it in server.js also.
-
-2. run `node server.js`
-
-3. Test by going to localhost:3000.
-   You can't get far until you create a customer member as described at the
-   [Merchant Quick Checkout documentation](http://developer.token.io/merchant-checkout/).
-
-This code uses a publicly-known developer key (the second parameter to
-`new TokenLib`). This normally works, but don't be surprised if
+This code uses a publicly-known developer key (the devKey line in the
+initializeSDK method). This normally works, but don't be surprised if
 it's sometimes rate-limited or disabled. If your organization will do
 more Token development and doesn't already have a developer key, contact
 Token to get one.

--- a/server.js
+++ b/server.js
@@ -70,6 +70,9 @@ if (member) {
     member.firstAlias().then(function (alias) {
         // launch server
         initServer(member, alias);
+    }, function (err) {
+        console.log("Something went wrong: " + err);
+        console.log("If member ID not found, `rm -r ./keys` and try again.");
     });
 } else {
     // Didn't find an existing merchant member. Create a new one.


### PR DESCRIPTION
We told folks to hand-edit code to get merchant-sample-js running. Good news: they got a merchant member with a non-nonsensical alias. Bad news: they had to hand-edit code.

This PR gives behavior similar to merchant-sample-java:

Look in keys dir. 

If see a file like m_1234_567, then log in as member with ID m:1234:567

Else, create a new member with a random alias.
